### PR TITLE
changed dye list for latest stable minetest_game

### DIFF
--- a/trm_dye/init.lua
+++ b/trm_dye/init.lua
@@ -1,4 +1,4 @@
-local colors = {"white", "lightgrey", "grey", "darkgrey", "black", "red", "orange", "yellow", "lime", "green", "aqua", "cyan", "sky_blue", "blue", "violet", "magenta", "red_violet"}
+local colors = {"white", "grey", "dark_grey", "black", "violet", "blue", "cyan", "dark_green", "green", "yellow", "brown", "orange", "red", "magenta", "pink"}
 for i=1,#colors do
 	treasurer.register_treasure("dye:"..colors[i], 0.0117, 1, {1,6}, nil, "crafting_component" )
 end


### PR DESCRIPTION
* some colors were deprecated from dyes variable in dyes mod (though they are in excolors, an unused list variable)
* added "dark_green", "brown", "pink" (not in excolors nor in original trm_dye)
* removed deprecated "lightgrey", "darkgrey" --[[without underscore--]], "red_violet", "aqua", "sky_blue" (see unified_dyes for similar ones--a different trm would be needed for that since it is not in minetest_game and this modpack is for minetest_game)